### PR TITLE
config: switch to Shanee's PAT patch, update alcID

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1762,7 +1762,7 @@
 				<key>Count</key>
 				<integer>0</integer>
 				<key>Enabled</key>
-				<true/>
+				<false/>
 				<key>Find</key>
 				<data>icCB4v//AP+BygAAAQC5dwIAAA==</data>
 				<key>Identifier</key>
@@ -1792,7 +1792,7 @@
 				<key>Count</key>
 				<integer>0</integer>
 				<key>Enabled</key>
-				<false/>
+				<true/>
 				<key>Find</key>
 				<data>icCB4v//AP+BygAAAQC5dwIAAA==</data>
 				<key>Identifier</key>
@@ -2066,7 +2066,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>alcid=99 npci=0x3000 debug=0x100 keepsyms=1 revcpu=1</string>
+				<string>alcid=69 npci=0x3000 debug=0x100 keepsyms=1 revcpu=1</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>


### PR DESCRIPTION
Shanee's patch increases AMD GPU performance, and the current alcID doesn't support HDMI audio.